### PR TITLE
change prices from string to number to avoid string concatenation on listing addition

### DIFF
--- a/pages/api/listings/new.js
+++ b/pages/api/listings/new.js
@@ -20,7 +20,7 @@ export default requireAuthEndpoint(async (req, res) => {
       image:
         'https://images.unsplash.com/photo-1528909514045-2fa4ac7a08ba?ixlib=rb-1.2.1&auto=format&fit=crop&w=2700&q=80',
       price: {
-        amount: price,
+        amount: parseInt(price),
         currency: currency,
       },
     };


### PR DESCRIPTION
On the listing page, prices are added as strings for user-created listings.

e.g. User creates a listing with price 1 USD
The api returns total amount 0 + "100" + 10 = "010010" in the reduce() function

expected behaviour should be returning 110 (as a number, not a string)
